### PR TITLE
IAのタイトル修正

### DIFF
--- a/src/pages/documents/ia.md
+++ b/src/pages/documents/ia.md
@@ -1,6 +1,6 @@
 ---
 layout: ../../layouts/ArticleLayout.astro
-title: インフォメーションアーキテクト
+title: 情報アーキテクチャ
 description:
 tag: word,IA
 ---


### PR DESCRIPTION
「〜アーキテクト（分野に従事する人）」よりも「〜アーキテクチャ（分野）」を表題にしたほうが適切と思います。